### PR TITLE
Added rtk_gps_ntrip meta-peckage

### DIFF
--- a/ntrip_client/scripts/ntrip_ros.py
+++ b/ntrip_client/scripts/ntrip_ros.py
@@ -49,7 +49,7 @@ class NTRIPRos(Node):
         ('cert', 'None'),
         ('key', 'None'),
         ('ca_cert', 'None'),
-        ('rtcm_frame_id', 'odom'),
+        ('rtcm_frame_id', 'gps'),
         ('nmea_max_length', NMEA_DEFAULT_MAX_LENGTH),
         ('nmea_min_length', NMEA_DEFAULT_MIN_LENGTH),
         ('rtcm_message_package', _MAVROS_MSGS_NAME),

--- a/rtk_gps_ntrip/CMakeLists.txt
+++ b/rtk_gps_ntrip/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(rtk_gps_ntrip)
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/rtk_gps_ntrip/launch/rtk_gps_ntrip_launch.py
+++ b/rtk_gps_ntrip/launch/rtk_gps_ntrip_launch.py
@@ -1,0 +1,33 @@
+import os
+
+import ament_index_python.packages
+import launch
+import launch.launch_description_sources
+import launch_ros.actions
+
+
+def generate_launch_description():
+    ublox_launch_directory = os.path.join(
+        ament_index_python.packages.get_package_share_directory('ublox_gps'),
+        'launch'
+    )
+    
+    
+    ntrip_launch_directory = os.path.join(
+        ament_index_python.packages.get_package_share_directory('ntrip_client')
+    )
+    
+    
+
+    ublox_launch = launch.actions.IncludeLaunchDescription(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
+            ublox_launch_directory + '/ublox_gps_node-launch.py'))
+
+    ntrip_launch = launch.actions.IncludeLaunchDescription(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
+            ntrip_launch_directory + '/ntrip_client_launch.py'))
+
+    return launch.LaunchDescription([
+        ntrip_launch,
+        ublox_launch
+    ])

--- a/rtk_gps_ntrip/launch/rtk_gps_ntrip_launch.py
+++ b/rtk_gps_ntrip/launch/rtk_gps_ntrip_launch.py
@@ -12,13 +12,11 @@ def generate_launch_description():
         'launch'
     )
     
-    
     ntrip_launch_directory = os.path.join(
         ament_index_python.packages.get_package_share_directory('ntrip_client')
     )
     
     
-
     ublox_launch = launch.actions.IncludeLaunchDescription(
         launch.launch_description_sources.PythonLaunchDescriptionSource(
             ublox_launch_directory + '/ublox_gps_node-launch.py'))

--- a/rtk_gps_ntrip/package.xml
+++ b/rtk_gps_ntrip/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rtk_gps_ntrip</name>
+  <version>0.0.1</version>
+  <description>Meta-package that integrates ublox gps package and ntrip_client package for launch and build.</description>
+  <maintainer email="gabriel.rocha@ieee.org">toffanetto</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>ublox</exec_depend>
+  <exec_depend>ntrip_client</exec_depend>
+  <exec_depend>fix2nmea</exec_depend>
+  <exec_depend>rtcm_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ublox_gps/config/vilma02_gnss_params.yaml
+++ b/ublox_gps/config/vilma02_gnss_params.yaml
@@ -1,0 +1,37 @@
+# Configuration Settings for C94-M8P device
+ublox_gps_node:
+  ros__parameters:
+    debug: 1                    # Range 0-4 (0 means no debug statements will print)
+    device: /dev/ttyACM0
+    
+    frame_id: gps
+    rate: 1.0                   # in Hz
+    nav_rate: 1                 
+                                
+    dynamic_model: portable
+    
+    uart1:
+      baudrate: 57600
+     
+    gnss:
+      glonass: true
+      beidou: true
+      gps: true
+      qzss: true
+      galileo: true
+      imes: false
+    
+    # TMODE3 Config
+    tmode3: 0                   # Survey-In Mode
+    sv_in:
+      reset: false               # True: disables and re-enables survey-in (resets)
+                                # False: Disables survey-in only if TMODE3 is
+                                # disabled
+      min_dur: 300              # Survey-In Minimum Duration [s]
+      acc_lim: 3.0              # Survey-In Accuracy Limit [m]
+
+    inf:
+      all: true                   # Whether to display all INF messages in console
+    
+    publish:
+      aid/all: false

--- a/ublox_gps/launch/ublox_gps_node-launch.py
+++ b/ublox_gps/launch/ublox_gps_node-launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
     config_directory = os.path.join(
         ament_index_python.packages.get_package_share_directory('ublox_gps'),
         'config')
-    params = os.path.join(config_directory, 'zed_f9p.yaml')
+    params = os.path.join(config_directory, 'vilma02_gnss_params.yaml')
     ublox_gps_node = launch_ros.actions.Node(package='ublox_gps',
                                              executable='ublox_gps_node',
                                              output='both',


### PR DESCRIPTION
Greetings!

I was looking to use your repository, and it is very useful, given the ublox ros2 drivers and the ntrip client node. But, for use, I missed a meta-package that builds all the necessary packages based on dependencies and a launch file to launch GPS and NTRIP Client together.

Thus, I created this meta-package with the launch file provided by this pull request.

Best regards,
Gabriel Toffanetto.